### PR TITLE
Fix RPC struct sanity check

### DIFF
--- a/AMSMB2/MSRPC.swift
+++ b/AMSMB2/MSRPC.swift
@@ -81,7 +81,7 @@ class MSRPC {
             let commentActualCount = Int(commentActualCount_32)
             
             offset += 12
-            if offset + nameActualCount * 2 > data.count {
+            if offset + commentActualCount * 2 > data.count {
                 throw POSIXError(.EBADRPC)
             }
             


### PR DESCRIPTION
Hi,
I currently get a bad RPC struct error when listing shares where the name is longer than the comment; this looks to be the culprit.
Great library btw!