### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "LibraryName",
-    // platforms: [.iOS("9.0"), .macOS("10.11"), tvOS("9.0"), .watchOS("2.0")],
+    // platforms: [.iOS("9.0"), .macOS("10.11"), tvOS("9.0")],
     products: [
         .library(name: "AMSMB2", targets: ["AMSMB2"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "LibraryName",
+    // platforms: [.iOS("9.0"), .macOS("10.11"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "AMSMB2", targets: ["AMSMB2"])
+    ],
+    targets: [
+        .target(
+            name: "AMSMB2",
+            path: "AMSMB2"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is small Swift library for iOS, macOS and tvOS which wraps [libsmb2](https:
 [![Release version][release-image]][release-url]
 [![CocoaPods version][pod-release-image]][cocoapods]
 [![Carthage compatible][carthage-image]](https://github.com/Carthage/Carthage)
+[![Accio supported](accio-image)](https://github.com/JamitLabs/Accio)
 
 ## Install
 
@@ -27,6 +28,27 @@ Or add this to Cartfile:
 ```
 github "amosavian/AMSMB2"
 ```
+
+### Accio
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/amosavian/AMSMB2.git", .upToNextMajor(from: "1.8.0")),
+```
+
+Next, add `AMSMB2` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "AMSMB2",
+    ]
+),
+```
+
+Then run `accio update`.
 
 ### Manually
 
@@ -146,5 +168,6 @@ You **must** link this library dynamically to your app if you intend to distribu
 [release-image]: https://img.shields.io/github/release/amosavian/AMSMB2.svg
 [pod-release-image]: https://img.shields.io/cocoapods/v/AMSMB2.svg
 [carthage-image]: https://img.shields.io/badge/Carthage-compatible-4BC51D.svg
+[accio-image]: https://img.shields.io/badge/Accio-supported-0A7CF5.svg
 [cocoapods-downloads]: https://img.shields.io/cocoapods/dt/AMSMB2.svg
 [cocoapods-apps]: https://img.shields.io/cocoapods/at/AMSMB2.svg


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.