### PR TITLE
Update libsmb2 reference and make changes necessary for new OS's

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Dependencies/libsmb2"]
+	path = Dependencies/libsmb2
+	url = git@github.com:vhawley/libsmb2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Dependencies/libsmb2"]
-	path = Dependencies/libsmb2
-	url = https://github.com/amosavian/libsmb2.git

--- a/Package.swift
+++ b/Package.swift
@@ -28,11 +28,11 @@ let package = Package(
                 "lib/CMakeLists.txt",
                 "lib/libsmb2.syms",
                 "lib/Makefile.am",
-                "lib/Makefile.DC_KOS",
-                "lib/Makefile.PS2_EE",
-                "lib/Makefile.PS2_IOP",
+                "lib/Makefile.AMIGA_OS3",
+                "lib/Makefile.AMIGA_AROS",
+                "lib/Makefile.AMIGA",
                 "lib/Makefile.PS3_PPU",
-                "lib/Makefile.PS4",
+                "lib/ps2"
             ],
             sources: [
                 "lib",

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -28,11 +28,11 @@ let package = Package(
                 "lib/CMakeLists.txt",
                 "lib/libsmb2.syms",
                 "lib/Makefile.am",
-                "lib/Makefile.DC_KOS",
-                "lib/Makefile.PS2_EE",
-                "lib/Makefile.PS2_IOP",
+                "lib/Makefile.AMIGA_OS3",
+                "lib/Makefile.AMIGA_AROS",
+                "lib/Makefile.AMIGA",
                 "lib/Makefile.PS3_PPU",
-                "lib/Makefile.PS4",
+                "lib/ps2"
             ],
             sources: [
                 "lib",


### PR DESCRIPTION
 iOS/tvOS 18 and macOS Sequoia need a new sys/types import in order to build properly. When doing this, I also updated the libsmb2 branch, so my pull request is pointing to that as well