### PR TITLE
Allow SPM to choose linking type by removing explicit .dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
     products: [
         .library(
             name: "AMSMB2",
-            type: .dynamic,
             targets: ["AMSMB2"]
         ),
     ],


### PR DESCRIPTION
###  Description 

#### **Summary**

This PR removes the explicit `type: .dynamic` from the library product definition in `Package.swift`.

#### **Why this is needed**

Currently, the explicit dynamic linking causes issues when `AMSMB2` is used as a dependency within another dynamic framework (an "Umbrella Framework"). In such cases, the linker often fails with `Undefined symbols` because the binary isn't properly merged or propagated.

By removing the explicit type, Swift Package Manager (SPM) can automatically decide whether to link statically or dynamically based on the consumer's needs:

* **Static (default):** Ideal for umbrella frameworks and apps that want to benefit from "Dead Code Stripping" and simpler distribution.
* **Dynamic:** Still achievable if the consumer explicitly requests it in their own `Package.swift`.

#### **Changes**

* Removed `type: .dynamic` from `.library` in `Package.swift`.

#### **Impact**

* Improves compatibility with complex modular architectures.
* Fixes `Undefined symbols for architecture arm64` errors in nested dependency graphs.
* No breaking changes for existing users who link the package directly to their app targets.
