### PR TITLE
Expose monitorItem as open

### DIFF
--- a/AMSMB2/AMSMB2.swift
+++ b/AMSMB2/AMSMB2.swift
@@ -1372,7 +1372,7 @@ public class SMB2Manager: NSObject, NSSecureCoding, Codable, NSCopying, CustomRe
     ///   - path: Path of file or folder to be monitored for changes.
     ///   - filter: Change types that will be monitored.
     ///   - completionHandler: closure will be run after a change in montored file/folder.
-    func monitorItem(
+    open func monitorItem(
         atPath path: String,
         for filter: SMB2FileChangeType,
         completionHandler: @Sendable @escaping (_ result: Result<[SMB2FileChangeInfo], any Error>) -> Void
@@ -1391,14 +1391,14 @@ public class SMB2Manager: NSObject, NSSecureCoding, Codable, NSCopying, CustomRe
             return try file.changeNotify(for: filter)
         }
     }
-    
+
     /// Monitor file/folder for changes and returns when a change occurs.
     ///
     /// - Parameters:
     ///   - path: Path of file or folder to be monitored for changes.
     ///   - filter: Change types that will be monitored.
     @discardableResult
-    func monitorItem(atPath path: String, for filter: SMB2FileChangeType) async throws -> [SMB2FileChangeInfo] {
+    open func monitorItem(atPath path: String, for filter: SMB2FileChangeType) async throws -> [SMB2FileChangeInfo] {
         try await withCheckedThrowingContinuation { continuation in
             monitorItem(atPath: path, for: filter, completionHandler: asyncHandler(continuation))
         }


### PR DESCRIPTION
## What

Mark both \`SMB2Manager.monitorItem\` overloads (completion-handler + async) as \`open\` so they can be called from outside the AMSMB2 module.

## Why

Every sibling API on \`SMB2Manager\` — \`contentsOfDirectory\`, \`attributesOfItem\`, \`contents(atPath:range:)\`, \`downloadItem\`, \`move\`, etc. — is declared \`open\`. The doc comments on \`monitorItem\` already describe it as part of the public API (\"Monitor file/folder for changes…\"), the result type \`SMB2FileChangeInfo\` and the filter type \`SMB2FileChangeType\` are both \`public struct\`, and the test coverage treats it alongside the public surface. The non-public visibility appears to be an oversight rather than a deliberate encapsulation choice.

Being unable to call \`monitorItem\` means client code can't use SMB2 CHANGE_NOTIFY push notifications without forking the package.

## Concrete use case

I'm building a music library scanner that currently polls folders for changes. Moving to CHANGE_NOTIFY eliminates redundant \`contentsOfDirectory\` round-trips on rescans and lets the app react to new albums being dropped on the NAS within a few seconds. The implementation is ready locally — it just can't reach \`monitorItem\` behind the \`internal\` wall.

## Change

Two three-character edits, both from default visibility to \`open\`. Matches the project's access-modifier convention for the rest of \`SMB2Manager\`'s async + completion-handler API. No behaviour change.

## Verification

- \`xcodebuild -scheme AMSMB2 -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build\` — succeeds (no new warnings, same libsmb2 C warnings as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)