### PR TITLE
Don't send FILE_NO_INTERMEDIATE_BUFFERING on directory CHANGE_NOTIFY open

### DIFF
--- a/AMSMB2/AMSMB2.swift
+++ b/AMSMB2/AMSMB2.swift
@@ -1378,21 +1378,14 @@ public class SMB2Manager: NSObject, NSSecureCoding, Codable, NSCopying, CustomRe
         completionHandler: @Sendable @escaping (_ result: Result<[SMB2FileChangeInfo], any Error>) -> Void
     ) {
         with(completionHandler: completionHandler) { client in
-            // Drop O_SYNC for directory opens. O_SYNC maps to libsmb2's
-            // SMB2_FILE_NO_INTERMEDIATE_BUFFERING; per MS-FSCC §2.1.5.1
-            // that option does not apply to directories and Windows
-            // rejects the CREATE with STATUS_INVALID_PARAMETER when
-            // both FILE_DIRECTORY_FILE and FILE_NO_INTERMEDIATE_BUFFERING
-            // are set on the same CREATE.
-            var flags: Int32 = O_RDONLY
+            var flags = O_RDONLY | O_SYNC
             switch try client.stat(path).resourceType {
             case .directory:
                 flags |= O_DIRECTORY
             case .link:
                 flags |= O_SYMLINK
-                flags |= O_SYNC
             default:
-                flags |= O_SYNC
+                break
             }
             let file = try SMB2FileHandle(path: path, flags: flags, on: client)
             return try file.changeNotify(for: filter)

--- a/AMSMB2/AMSMB2.swift
+++ b/AMSMB2/AMSMB2.swift
@@ -1378,14 +1378,21 @@ public class SMB2Manager: NSObject, NSSecureCoding, Codable, NSCopying, CustomRe
         completionHandler: @Sendable @escaping (_ result: Result<[SMB2FileChangeInfo], any Error>) -> Void
     ) {
         with(completionHandler: completionHandler) { client in
-            var flags = O_RDONLY | O_SYNC
+            // Drop O_SYNC for directory opens. O_SYNC maps to libsmb2's
+            // SMB2_FILE_NO_INTERMEDIATE_BUFFERING; per MS-FSCC §2.1.5.1
+            // that option does not apply to directories and Windows
+            // rejects the CREATE with STATUS_INVALID_PARAMETER when
+            // both FILE_DIRECTORY_FILE and FILE_NO_INTERMEDIATE_BUFFERING
+            // are set on the same CREATE.
+            var flags: Int32 = O_RDONLY
             switch try client.stat(path).resourceType {
             case .directory:
                 flags |= O_DIRECTORY
             case .link:
                 flags |= O_SYMLINK
+                flags |= O_SYNC
             default:
-                break
+                flags |= O_SYNC
             }
             let file = try SMB2FileHandle(path: path, flags: flags, on: client)
             return try file.changeNotify(for: filter)

--- a/AMSMB2/FileHandle.swift
+++ b/AMSMB2/FileHandle.swift
@@ -628,11 +628,19 @@ extension SMB2FileHandle {
         
         init(flags: Int32) {
             self = []
-            if (flags & O_SYNC) != 0 {
-                insert(.noIntermediateBuffering)
-            }
-            if (flags & O_DIRECTORY) != 0 {
+            let isDirectory = (flags & O_DIRECTORY) != 0
+            if isDirectory {
                 insert(.directoryFile)
+            }
+            // FILE_NO_INTERMEDIATE_BUFFERING is invalid on directories
+            // per MS-FSCC §2.1.5.1; Windows enforces this strictly and
+            // rejects the CREATE with STATUS_INVALID_PARAMETER when
+            // both FILE_DIRECTORY_FILE and FILE_NO_INTERMEDIATE_BUFFERING
+            // are present on the same open. Suppress the buffering flag
+            // when O_DIRECTORY is also set so callers don't have to
+            // remember the constraint at every directory open site.
+            if (flags & O_SYNC) != 0 && !isDirectory {
+                insert(.noIntermediateBuffering)
             }
             if (flags & O_SYMLINK) != 0 {
                 insert(.openReparsePoint)

--- a/AMSMB2Tests/CreateOptionsTests.swift
+++ b/AMSMB2Tests/CreateOptionsTests.swift
@@ -1,0 +1,57 @@
+//
+//  CreateOptionsTests.swift
+//  AMSMB2
+//
+//  Locks in the constraint that `CreateOptions.init(flags:)` does not
+//  emit `.noIntermediateBuffering` when `O_DIRECTORY` is also set.
+//
+//  Per MS-FSCC §2.1.5.1, FILE_NO_INTERMEDIATE_BUFFERING does not apply
+//  to directories. Windows enforces this strictly: a CREATE that
+//  carries both FILE_DIRECTORY_FILE and FILE_NO_INTERMEDIATE_BUFFERING
+//  is rejected with STATUS_INVALID_PARAMETER (0xC000000D) before any
+//  follow-up request (CHANGE_NOTIFY, etc.) ever runs.
+//
+//  Distributed under MIT license.
+//
+
+import XCTest
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+@testable import AMSMB2
+
+final class CreateOptionsTests: XCTestCase {
+
+    func testO_SYNCAloneEmitsNoIntermediateBuffering() {
+        let opts = SMB2FileHandle.CreateOptions(flags: O_RDONLY | O_SYNC)
+        XCTAssertTrue(opts.contains(.noIntermediateBuffering),
+                      "O_SYNC on a non-directory open should set .noIntermediateBuffering")
+        XCTAssertFalse(opts.contains(.directoryFile))
+    }
+
+    func testO_DIRECTORYAloneSetsDirectoryFileWithoutBuffering() {
+        let opts = SMB2FileHandle.CreateOptions(flags: O_RDONLY | O_DIRECTORY)
+        XCTAssertTrue(opts.contains(.directoryFile))
+        XCTAssertFalse(opts.contains(.noIntermediateBuffering))
+    }
+
+    func testO_SYNCWithO_DIRECTORYSuppressesNoIntermediateBuffering() {
+        // The whole point of this fix: callers may pass O_RDONLY | O_SYNC
+        // and then OR in O_DIRECTORY after a stat result; the resulting
+        // CreateOptions must NOT include .noIntermediateBuffering or
+        // Windows will reject the CREATE.
+        let opts = SMB2FileHandle.CreateOptions(flags: O_RDONLY | O_SYNC | O_DIRECTORY)
+        XCTAssertTrue(opts.contains(.directoryFile),
+                      "O_DIRECTORY should still set .directoryFile")
+        XCTAssertFalse(opts.contains(.noIntermediateBuffering),
+                       "O_SYNC must not set .noIntermediateBuffering when O_DIRECTORY is also set (MS-FSCC §2.1.5.1)")
+    }
+
+    func testO_SYMLINKSetsOpenReparsePoint() {
+        let opts = SMB2FileHandle.CreateOptions(flags: O_RDONLY | O_SYMLINK)
+        XCTAssertTrue(opts.contains(.openReparsePoint))
+        XCTAssertFalse(opts.contains(.directoryFile))
+    }
+}


### PR DESCRIPTION
## Problem

`SMB2Manager.monitorItem(atPath:for:)` opens the target with `O_RDONLY | O_SYNC`, then adds `O_DIRECTORY` when the stat result is a directory. libsmb2 translates `O_SYNC` into SMB2's `FILE_NO_INTERMEDIATE_BUFFERING` and `O_DIRECTORY` into `FILE_DIRECTORY_FILE`, so the CREATE carries both flags together.

Per [MS-FSCC §2.1.5.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4b328f52-bfe2-4e76-bce3-2db7f37f9069), `FILE_NO_INTERMEDIATE_BUFFERING` does not apply to directories. Windows enforces that strictly — the CREATE is rejected with `STATUS_INVALID_PARAMETER` (0xC000000D) before CHANGE_NOTIFY is ever sent. The surfaced error looks as if CHANGE_NOTIFY itself is failing, which is why `testMonitor` gated with `XCTSkipIf(true)` has been presumed to be a CHANGE_NOTIFY issue.

Reproduced against Windows 11 (latest build) built-in SMB sharing with the current libsmb2 pin (`d2c69861`): every filter value rejects identically — `fileName`, `directoryName`, `attributes`, `fileName|recursive`, `all` — because the server never reaches the notify step. Dropping `O_SYNC` from the directory branch and the CREATE succeeds.

## Fix

Only attach `O_SYNC` to non-directory opens (file and reparse-point paths, where non-buffered I/O is meaningful). A short comment records the spec reference so a future refactor doesn't put it back.

## Test plan

- Manually ran `testMonitor` against Windows 11 SMB (with `XCTSkipIf` removed locally) — with this patch the CREATE succeeds and the server fires a `CHANGE_NOTIFY` response on file writes.
- Keeping the `XCTSkipIf` gate for now; a separate crash on the response path inside `SMB2Client.generic_handler` (filed as #136) needs to land before the test can be enabled in CI.
- Relates to #134 — this addresses the `testMonitor` failure that has been blocking `monitorItem` from being exposed publicly. #136 is the remaining blocker.